### PR TITLE
Add local_config.yml for local development, update docs

### DIFF
--- a/Development/Contributing-to-Heads-Wiki.md
+++ b/Development/Contributing-to-Heads-Wiki.md
@@ -34,7 +34,7 @@ The simplest way to make a small change to existing pages is directly on GitHub
  as it requires no software to be installed.
 
 * Start by login into GitHub and forking
-[osresearch/heads-wiki](https://github.com/osresearch/heads-wiki).
+[linuxboot/heads-wiki](https://github.com/linuxboot/heads-wiki).
 * Find the desired page on [osresearch.net](http://osresearch.net/).  Click on
 the link at the bottom of the page saying *"Edit this page on GitHub."*
 * This will bring you to an editor on GitHub and should mention that you do not
@@ -68,25 +68,17 @@ Additionally, the theme will also need to be installed as the remote theme does
 
 After installing Jekyll and the Just the Docs theme you may run the wiki on your local system for faster testing and development.
 * log in to GitHub and fork
-[osresearch/heads-wiki](https://github.com/osresearch/heads-wiki).  Then clone
+[linuxboot/heads-wiki](https://github.com/linuxboot/heads-wiki).  Then clone
 your fork locally.
-* Navigate to the base of the locally cloned repo and alter `_config.yml` to use
- the local theme.  The simplest way is to comment out the line that beings
- `remote_theme` and add a line `theme: "just-the-docs"`
-
- ```yaml
- # remote_theme: pmarsceill/just-the-docs
- theme: "just-the-docs"
- ```
 * Now start Jekyll with:
 ```bash
-$> jekyll serve
+$> jekyll serve --config local_config.yml
 ```
 This will start the Jekyll development web server and should be viewable in a
 web browser at `http://localhost:4000/`
 
 * create a branch in git for your changes
-* Make the desired changes, commit them.  **BE SURE NOT TO ADD `_config.yml`**
+* Make the desired changes, commit them.  **BE SURE NOT TO ADD `_config.yml` or `local_config.yml`**
 to your changes.
 * Push the changes to your forked repo on github
 
@@ -109,4 +101,4 @@ Please verify `https://YOUR_USERNAME_HERE.github.io/heads-wiki/` with `https://v
 
 ### Pushing Changes Upstream
 
-Create a pull request in the osresearch/heads-wiki project that points to your changes to request review and contribute back to the parent project.
+Create a pull request in the linuxboot/heads-wiki project that points to your changes to request review and contribute back to the parent project.

--- a/local_config.yml
+++ b/local_config.yml
@@ -1,5 +1,5 @@
-#This is remote configuration, used by github for github pages rendering. See local_config.yml for local jekyll serving of pages editions 
-remote_theme: just-the-docs/just-the-docs
+#This is local jekyll for local rendering of edits, used by github for github pages. Use with: 'jekyll serve --config local_config.yml'
+theme: "just-the-docs"
 color_scheme: dark
 heading_anchors: true
 aux_links:


### PR DESCRIPTION
- replace osresearch->linuxboot
- point jekyll to local_config.yml
- replace ust-the-docs ref to point to upstream just-the-docs for github pages rendering