### PR TITLE
index.md: show both fbwhiptail(high res)/whiptail(low res) main menu

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,8 +7,15 @@ permalink: /
 nav_order: 1
 ---
 
+Heads main menu
+===
 
-![Heads booting on an x230](https://user-images.githubusercontent.com/827570/156627927-7239a936-e7b1-4ffb-9329-1c422dc70266.jpeg)
+Left: laptop/worskstation. Right: server (BMC/SSH/Console)
+<a href="https://github.com/user-attachments/assets/69621d18-c4ed-4fb9-bf35-02768b64cd76" target="_blank">
+  <img src="https://github.com/user-attachments/assets/69621d18-c4ed-4fb9-bf35-02768b64cd76"
+       alt="Heads booting on qemu-fbwhiptail-tpm2-hotp and qemu-whiptail-tpm1"
+       style="width: 100%; max-width: 800px; height: auto; display: block; margin: 1em auto;">
+</a>
 
 Overview
 ===


### PR DESCRIPTION
Fixes https://github.com/linuxboot/heads-wiki/issues/188
(Putting this as context for future linuxboot+kexec+linux kernel simpledrm related needed collaboration)

---
commit log:

This shows the power of using fbwhiptail/fbwhiptail to drive menus under Heads.

Whiptail is command-line utility used in shell scripts to create text-based user interfaces (TUIs) in a terminal (console). FBwhiptail is a whiptail wrapper, aimed at driving a reduced feature set of whiptail but for high resolution Frame Buffer (FB), intruduced by Purism.

By using Whiptail in the shell scripts, we are able to drive both high resolution graphics for laptops and workstations into coreboot initialized simple framebuffer, picked up by efifb linux kernel driver, which permits us to kexec into a full featured linux kernel, at the condition that the initramfs of that next kernel also provides efifb, which is currently being deprecated. As of now, neither simplefb, nor simpledrm permits the first kernel context (Heads) to be passed to the next kernel to provide early console access for the user to type its LUKS decryption passphrase at systemd prompt if efifb is not provided in the next kernel's initramfs. This is the case with Ubuntu 20.04+, but not Debian nor Fedora as far as I know. Ubuntu is not going back into their decision of readding efifb into their distributed initramfs as can be seen in issue https://github.com/linuxboot/heads/issues/1641 Mitigation to this for Heads users wanting to boot into OSes that deprecates LinuxBoot based implementations is to enable TPM Disk Unlock Key, so that the decryption key passphrase is passed into a cpio, not asked by systemd which doesn't have a fully functional console yet; only after rootfs is fully accessible and full GPU drivers replaces simpledrm/simplefb.

Let's remember that neither simpledrm nor simplefb can expose their framebuffer addresses to be passed to the next kernel, same applying to fully fledged linux kernel drivers for i915drm/i915 which needs insecure parameters to be passed. So for the future of linuxboot implementations desiring to provide a great UX, the issue needs to be tackled from coreboot to provide simpledrm compatible framebuffer, and for kexec to be able to pass that framebuffer to next kernel.

---

CC @JonathonHall-Purism 