### PR TITLE
index.md: add '2025 - Linux Foundation Member Summit - Ronald (Ron) Minnich - Deploying Linux as Firmware at Global Scale: Update' presentation paper

### DIFF
--- a/index.md
+++ b/index.md
@@ -68,6 +68,7 @@ Conferences
 * [2023 - FOSDEM - Thierry Laurion - Heads status update](https://archive.fosdem.org/2023/schedule/event/heads_status_update/)
 * [2024 - QubesOS mini-summit - Thierry Laurion - Heads rolling release : roles of upstream and downstream forks (Design Session)](https://youtu.be/mAb_kHrF6SQ?list=PLuISieMwVBpL5S7kPUHKenoFj_YJ8Y0_d)
 * [2024 - QubesOS mini-summit - Jan Suhr & Thierry Laurion - Future of Measured Boot such as Heads (Design Session)](https://youtu.be/ZPeidhgNBtg?list=PLuISieMwVBpL5S7kPUHKenoFj_YJ8Y0_d)
+* [2025 - Linux Foundation Member Summit - Ronald (Ron) Minnich - Deploying Linux as Firmware at Global Scale: Update](https://github.com/user-attachments/files/20680368/Deploying.Linux.as.firmware.at.global.scale.--.LF.2025.pdf)
 
 Articles
 ===


### PR DESCRIPTION
This unrecorded conference: https://lfms25.sched.com/event/1urX2/deploying-linux-as-firmware-at-global-scale-update-ronald-minnich-hewlett-packard

PDF saved through https://github.com/linuxboot/heads-wiki/issues/191
Closes #191 

TODO: maybe switch to archive.org but wasn't able to save archive of it and archive.as same story.