### PR TITLE
Update SPI-Programmer-Best-Practices.md

### DIFF
--- a/Installing-and-Configuring/Flashing-Guides/SPI-Programmer-Best-Practices.md
+++ b/Installing-and-Configuring/Flashing-Guides/SPI-Programmer-Best-Practices.md
@@ -183,7 +183,7 @@ sudo flashrom --programmer ft2232_spi:type=2232H,port=B,divisor=4
 ```bash
 sudo flashrom --programmer ch347_spi
 # With higher clock (example):
-sudo flashrom --programmer ch347_spi --spispeed 60000
+sudo flashrom --programmer ch347_spi
 ```
 
 ### CH341A Rev 1.6+


### PR DESCRIPTION
Remove default SPI Speed for the CH347.  I think the remaining SPI Speed documentation should be left in as it provides help for those who want to try a slower speed if getting a large number of errors.