### PR TITLE
Properly mentioning X280. @tlaurion

### DIFF
--- a/About/Heads-threat-model.md
+++ b/About/Heads-threat-model.md
@@ -222,7 +222,7 @@ for details.
 | **T420** | 2nd Gen Sandy Bridge | ⚠️ EOL (no official ESU date; last microcode 2019-05-14) | ✅ Protected | ✅ Protected | ✅ Protected |
 | **T430** | 3rd Gen Ivy Bridge | ⚠️ EOL (no official ESU date; last microcode 2019-05-14) | ✅ Protected | ✅ Protected | ✅ Protected |
 | **T440p** | 4th Gen Haswell | ⚠️ EOL Jun 30, 2021 | ✅ Protected | ✅ Protected | ✅ Protected |
-| **T480, T480s** | 8th Gen Kaby Lake-R | ⚠️ ESU Mar 31, 2026 ¹ | ❌ Not protected<br>[TPM GPIO reset bypass](https://mkukri.xyz/2024/06/01/tpm-gpio-fail.html) | ✅ Protected | ❌ Not protected |
+| **T480, T480s, X280** | 8th Gen Kaby Lake-R | ⚠️ ESU Mar 31, 2026 ¹ | ❌ Not protected<br>[TPM GPIO reset bypass](https://mkukri.xyz/2024/06/01/tpm-gpio-fail.html) | ✅ Protected | ❌ Not protected |
 | **T530** | 3rd Gen Ivy Bridge | ⚠️ EOL (no official ESU date; last microcode 2019-05-14) | ✅ Protected | ✅ Protected | ✅ Protected |
 | **Talos II** | POWER9 | Active | ✅ Protected | ✅ Protected | ✅ Protected |
 | **W530** | 3rd Gen Ivy Bridge | ⚠️ EOL (no official ESU date; last microcode 2019-05-14) | ✅ Protected | ✅ Protected | ✅ Protected |


### PR DESCRIPTION
Found by @tlaurion 
I have not found other applicable mentions.
m900 tower does also reference the t480 where other boards do not, alongside the flashing guide for the T430:
`m900_tower flashing guide`

>  Next, connect the clip of your SPI programmer to the chip (see the [SPI Programmer Best Practices guide]({{ site.baseurl }}/SPI-Programmer-Best-Practices/) for recommended hardware and example commands). Next, connect the programmer to the USB port of your other Linux-based computer with flashrom/flashprog installed. In this setup, the red wire should be where the dot is (the dot indicates pin 1). Here, please also see the flashing guide for the T430, T480.

No other board seems to do this.

`Porting.md` uses the T480 as the example, so nothing to interfere with there.

Lifted from his issue:

> Should I just add the X280 alongside, or change to xx80 if/when applicable. In theory there are at least five similar devices (T480 T480s T580 X280 X380 Yoga), and while not all of them currently have heads support, would that remain the case. It hasn't for Libreboot. For now I will probably just add it alongside.

Might also look at the `heads` repo for such things.