### PR TITLE
wiki: align PCR table to code, add note for TPM defend lock and further work needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jekyll-cache
 _site
+.code-graph/

--- a/About/Keys.md
+++ b/About/Keys.md
@@ -171,23 +171,27 @@ equivalent to the login password. Other operating systems might differ.
 
 ![TPM]({{ site.baseurl }}/images/TPM.jpg)
 
-0: Nothing for the moment (Populated by binary blobs where applicable for
-[SRTM](https://doc.coreboot.org/security/vboot/measured_boot.html#ibb-crtm))
+0: Not used. Would be populated by Intel Boot Guard (IBB via ACM) if
+enabled.
 
-1: Nothing for the moment
+1: Not used. Would be populated by coreboot with HWID digest and boot mode
+(`CONFIG_PCR_HWID`, `CONFIG_PCR_BOOT_MODE`) but runtime shows zero.
 
-2: coreboot's Boot block, ROM stage, RAM stage, Payload (Heads linux kernel and
-initrd)
+2: [coreboot measured boot](https://doc.coreboot.org/security/vboot/measured_boot.html#platform-configuration-registers)
+— bootblock, romstage, ramstage, payload, bootsplash.jpg, fallback/*.
 
-3: Nothing for the moment
+3: Runtime data slot — empty on all Heads builds. Coreboot can measure MRC
+cache and hwinfo.hex here (DIMM-swap detection), currently disabled.
 
-4: Boot mode (0 during `/init`, then `recovery` or `normal-boot`)
+4: Boot mode. Extended by `usb-init.sh`, `kexec-insert-key.sh`,
+`kexec-select-boot.sh`.
 
-5: Heads Linux kernel modules
+5: Kernel modules. Extended by `sbin/insmod.sh`.
 
-6: Drive LUKS headers
+6: LUKS headers. Extended by `qubes-measure-luks.sh` during DUK seal.
 
-7: Heads user-specific files stored in CBFS (config.user, GPG keyring, etc).
+7: Heads CBFS files and UEFI binaries. Extended by `cbfs-init.sh`,
+`uefi-init.sh`.
 
 (16): Used for TPM futurecalc of LUKS header when setting up a TPM disk
 encryption key
@@ -224,6 +228,11 @@ types a [TPM Disk Unlock key passphrase]({{ site.baseurl }}/Keys/#disk-unlock-ke
 Indeed, the PCRs measurements used to seal the Disk Unlock Key in TPM NV memory
 cannot unseal that secret, even with a good TPM Disk Unlock Key passphrase,
 while HOTP/TOTP should not be able to unseal either.
+
+Unseal can also fail due to TPM Dictionary Attack Lockout after too many failed
+authentication attempts. Heads sets a 10-try limit with 1-hour recovery during
+TPM reset. Pending: [PR #2124](https://github.com/linuxboot/heads/pull/2124)
+adds user-facing DA lockout detection and guidance.
 
 ### TCPA Event log
 From the [Recovery Shell]({{ site.baseurl }}/RecoveryShell/), it is possible to review PCR2 [TCPA event

--- a/About/Keys.md
+++ b/About/Keys.md
@@ -230,9 +230,11 @@ cannot unseal that secret, even with a good TPM Disk Unlock Key passphrase,
 while HOTP/TOTP should not be able to unseal either.
 
 Unseal can also fail due to TPM Dictionary Attack Lockout after too many failed
-authentication attempts. Heads sets a 10-try limit with 1-hour recovery during
-TPM reset. Pending: [PR #2124](https://github.com/linuxboot/heads/pull/2124)
-adds user-facing DA lockout detection and guidance.
+authentication attempts. On TPM 2, Heads enforces a 10-try limit with 1-hour
+recovery during TPM reset. On TPM 1, DA behavior is vendor-specific — Heads
+has no tooling to configure it. Pending:
+[PR #2124](https://github.com/linuxboot/heads/pull/2124) adds user-facing DA
+lockout detection and guidance.
 
 ### TCPA Event log
 From the [Recovery Shell]({{ site.baseurl }}/RecoveryShell/), it is possible to review PCR2 [TCPA event


### PR DESCRIPTION
## Summary

Aligns the TPM PCR table in `About/Keys.md` with actual runtime behavior verified against `cbmem -L` output from a real Heads build.

Fixes #245

## Changes

**PCR table corrections:**
- PCR 0: note Intel Boot Guard (IBB via ACM) as future use
- PCR 1: note coreboot Kconfig defines (`CONFIG_PCR_HWID`, `CONFIG_PCR_BOOT_MODE`) but runtime shows zero
- PCR 2: correct to specific CBFS files measured (bootblock, fallback/*, bootsplash.jpg) — not "every CBFS file"
- PCR 3: document as runtime data slot, currently empty, future DIMM-swap detection
- PCR 4-7: add script references (`usb-init.sh`, `kexec-insert-key.sh`, `kexec-select-boot.sh`, `sbin/insmod.sh`, `qubes-measure-luks.sh`, `cbfs-init.sh`, `uefi-init.sh`)
- PCR 16: preserved as original

**New content:**
- DA lockout note under "TPM_Unseal errors": explains TPM 2 enforced (10-try, 1h recovery) vs TPM 1 vendor-specific, links [PR #2124](https://github.com/linuxboot/heads/pull/2124) as pending

## Evidence

All claims verified against:
- `cbmem -L` output (real hardware TPM log)
- `initrd/bin/*.sh` (extend sites)
- `config/coreboot-*.config` (54 files)
- `build/x86/coreboot-25.12/src/security/tpm/tspi/crtm.c` (CBFS measurement routing)